### PR TITLE
Close Alpha Program with Beta Tease

### DIFF
--- a/ui/assets/package-lock.json
+++ b/ui/assets/package-lock.json
@@ -3696,14 +3696,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -3712,6 +3704,14 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -8272,15 +8272,6 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -8290,6 +8281,15 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/ui/assets/src/app/app.component.html
+++ b/ui/assets/src/app/app.component.html
@@ -11,13 +11,6 @@
           </h1>
 
           <p>
-            <b>
-              We're proud to offer our fully-automated ops platform to our alpha
-              testing community.
-            </b>
-          </p>
-
-          <p>
             Supergiant is a supported auto-scaling cloud service that just
             works. We’ve made Kubernetes auto-healing infrastructure and cloud
             portability accessible to developers who want to ship a scalable

--- a/ui/assets/src/app/app.module.ts
+++ b/ui/assets/src/app/app.module.ts
@@ -10,17 +10,20 @@ import { Angulartics2Module, Angulartics2GoogleTagManager } from 'angulartics2';
 import { AppComponent } from './app.component';
 import { RequestComponent } from './request/request.component';
 import { ClaimComponent } from './claim/claim.component';
+import { ClosedComponent } from './closed/closed.component';
 
 const appRoutes: Routes = [
-  { path: 'request', component: RequestComponent },
-  { path: '',      component: ClaimComponent },
+  // { path: 'request', component: RequestComponent },
+  // { path: 'claim',      component: ClaimComponent },
+  { path: '', component: ClosedComponent }
 ];
 
 @NgModule({
   declarations: [
     AppComponent,
     RequestComponent,
-    ClaimComponent
+    ClaimComponent,
+    ClosedComponent
   ],
   imports: [
       NgbModule.forRoot(),

--- a/ui/assets/src/app/closed/closed.component.html
+++ b/ui/assets/src/app/closed/closed.component.html
@@ -1,0 +1,36 @@
+<header class="container-fluid text-center">
+  <p>
+    Thanks for dropping by! Our latest alpha period has finished, but you can
+    request to join our upcoming Beta program, learn more about Supergiant,
+    and give us your feedback by joining our community.
+  </p>
+</header>
+
+<div class="container-fluid text-center">
+  <p>
+    <a href="https://supergiant.io/joinalpha" class="btn btn-primary">Request Beta Access</a>
+  </p>
+</div>
+
+<div class="container-fluid text-center">
+  <div class="row">
+    <div class="col">
+      <a href="https://supergiant.io/slack">
+        <i class="fa fa-slack fa-3x"></i><br>
+        Join our Slack channel
+      </a>
+    </div>
+    <div class="col">
+      <a href="https://supergiant.io/twitter">
+        <i class="fa fa-twitter fa-3x"></i><br>
+        Follow on Twitter
+      </a>
+    </div>
+    <div class="col">
+      <a href="https://supergiant.io/github">
+        <i class="fa fa-github fa-3x"></i><br>
+        Fork on Github
+      </a>
+    </div>
+  </div>
+</div>

--- a/ui/assets/src/app/closed/closed.component.spec.ts
+++ b/ui/assets/src/app/closed/closed.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ClosedComponent } from './closed.component';
+
+describe('ClosedComponent', () => {
+  let component: ClosedComponent;
+  let fixture: ComponentFixture<ClosedComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ClosedComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ClosedComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/ui/assets/src/app/closed/closed.component.ts
+++ b/ui/assets/src/app/closed/closed.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-closed',
+  templateUrl: './closed.component.html',
+  styleUrls: ['./closed.component.css']
+})
+export class ClosedComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}

--- a/ui/assets/src/styles.css
+++ b/ui/assets/src/styles.css
@@ -41,6 +41,15 @@ footer a:link:visited {
   color: #3559B1;
 }
 
+main a.btn.btn-primary:link,
+main a.btn.btn-primary:link:visited,
+header a.btn.btn-primary:link,
+header a.btn.btn-primary:link:visited,
+footer a.btn.btn-primary:link,
+footer a.btn.btn-primary:link:visited {
+  color: #fff;
+}
+
 main a:link:hover,
 main a:link:visited:hover,
 header a:link:hover,


### PR DESCRIPTION
This commit replaces the claim form and base route with a "closed"
component that announces the end of the Alpha program with a link
to request access to the Beta program.

Screenshot attached:
<img width="616" alt="screen shot 2017-09-21 at 1 42 19 pm" src="https://user-images.githubusercontent.com/676428/30715217-bda8ce98-9ed2-11e7-806a-c294339c5c97.png">
